### PR TITLE
Add missing styles for the widget description

### DIFF
--- a/02-create-your-developer-dashboard-widget-list/3-widget-component/src/sections/dashboard/Dashboard.module.scss
+++ b/02-create-your-developer-dashboard-widget-list/3-widget-component/src/sections/dashboard/Dashboard.module.scss
@@ -61,6 +61,15 @@
     padding: 0.5rem;
   }
 
+  &__description {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+
   &__footer {
     display: flex;
     align-items: center;


### PR DESCRIPTION
At this point we try to use this style at https://github.com/CodelyTV/react-from_zero_to_best_practices-course/blob/a38732b6f41c6403f7a6f6432bfc64463ce4f895/02-create-your-developer-dashboard-widget-list/3-widget-component/src/sections/dashboard/Dashboard.tsx#L67 but doesn't exist 👀